### PR TITLE
Android drop down scrolling > now fixed, had to set minHeight for the parent view & move the restrictions view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ amplifytools.xcconfig
 # testing
 cypress/screenshots
 cypress/videos
+__tests__/__snapshots__

--- a/App.js
+++ b/App.js
@@ -196,34 +196,34 @@ const App = () => {
             writeLocalStorage(council, alertLevel)
           }}
         />
-      </View>
 
-      <View style={styles.scrollContainer}>
-        <Text style={styles.title}>
-            Restrictions:
-        </Text>
+        <View style={styles.scrollContainer}>
+          <Text style={styles.title}>
+              Restrictions:
+          </Text>
 
-        <ScrollView>
-          
-          <Text style={styles.subTitle}>
-            Overview:
-          </Text>
-          <Text style={styles.body}>
-          {restrictions.overview}
-          </Text>
-          <Text style={styles.subTitle}>
-            Open:
-          </Text>
-          <Text style={styles.body}>
-          {restrictions.open}
-          </Text>
-          <Text style={styles.subTitle}>
-            Closed:
-          </Text>
-          <Text style={styles.body}>
-          {restrictions.closed}
-          </Text>
-        </ScrollView>
+          <ScrollView>
+            
+            <Text style={styles.subTitle}>
+              Overview:
+            </Text>
+            <Text style={styles.body}>
+            {restrictions.overview}
+            </Text>
+            <Text style={styles.subTitle}>
+              Open:
+            </Text>
+            <Text style={styles.body}>
+            {restrictions.open}
+            </Text>
+            <Text style={styles.subTitle}>
+              Closed:
+            </Text>
+            <Text style={styles.body}>
+            {restrictions.closed}
+            </Text>
+          </ScrollView>
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/styles.js
+++ b/styles.js
@@ -12,7 +12,8 @@ export default StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: '#fff',
-        zIndex: 10
+        zIndex: 10,
+        minHeight: '50%'
     },
     scrollContainer: {
       flex: 3,


### PR DESCRIPTION
Problem: 
We were unable to scroll through the items in the drop down list (only an issue on Android)

Solution: 
In order to scroll the list, we had to set the minHeight for the parent of the drop down list. However, this led to whitespace between the dropdown & restrictions Views. To address this, the restrictions View was moved into the dropdown View.

We can now scroll normally on Android, like we can on the other platforms.

Platforms tested: web on PC & Android.
All Jest & Cypress tests have passed.