### PR TITLE
Android drop down scrolling > now fixed, had to set minHeight for the parent view & move the restrictions view, Alert Level Object > use councilList instead, extra call was removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ amplifytools.xcconfig
 # testing
 cypress/screenshots
 cypress/videos
+__tests__/__snapshots__

--- a/App.js
+++ b/App.js
@@ -53,12 +53,12 @@ const App = () => {
   const [open, setOpen] = useState(false);
   const [councilList, setCouncilList] = useState([]);
   const [council, setCouncil] = useState('Glasgow');
+  const [alertLevel, setAlertLevel] = useState(0);
   const [restrictions, setRestrictions] = useState({
     overview: '',
     open: '',
     closed: ''
   });
-  const [alertLevel, setAlertLevel] = useState(0);
   
   // const [expoPushToken, setExpoPushToken] = useState('');
   // const [notification, setNotification] = useState(false);
@@ -89,11 +89,19 @@ const App = () => {
     } catch (err) { console.log(err) }
   }
 
-  // Get Alert Level for Current Council State from GQL
+  // get the alert level for the selected council, using the data in councilList
   async function fetchAlertLevel() {
     try {
-      const alert = await API.graphql(graphqlOperation(getCouncil, {id: council}));
-      setAlertLevel(alert.data.getCouncil.level);
+      let level = 0;
+
+      for (let area in councilList){
+        if (councilList[area].value === council){
+          level = councilList[area].level;
+          break;
+        }
+      }
+
+      setAlertLevel(level);
     } catch (err) { console.log(err) }
   }
 

--- a/App.js
+++ b/App.js
@@ -196,34 +196,34 @@ const App = () => {
             writeLocalStorage(council, alertLevel)
           }}
         />
-      </View>
 
-      <View style={styles.scrollContainer}>
-        <Text style={styles.title}>
-            Restrictions:
-        </Text>
+        <View style={styles.scrollContainer}>
+          <Text style={styles.title}>
+              Restrictions:
+          </Text>
 
-        <ScrollView>
-          
-          <Text style={styles.subTitle}>
-            Overview:
-          </Text>
-          <Text style={styles.body}>
-          {restrictions.overview}
-          </Text>
-          <Text style={styles.subTitle}>
-            Open:
-          </Text>
-          <Text style={styles.body}>
-          {restrictions.open}
-          </Text>
-          <Text style={styles.subTitle}>
-            Closed:
-          </Text>
-          <Text style={styles.body}>
-          {restrictions.closed}
-          </Text>
-        </ScrollView>
+          <ScrollView>
+            
+            <Text style={styles.subTitle}>
+              Overview:
+            </Text>
+            <Text style={styles.body}>
+            {restrictions.overview}
+            </Text>
+            <Text style={styles.subTitle}>
+              Open:
+            </Text>
+            <Text style={styles.body}>
+            {restrictions.open}
+            </Text>
+            <Text style={styles.subTitle}>
+              Closed:
+            </Text>
+            <Text style={styles.body}>
+            {restrictions.closed}
+            </Text>
+          </ScrollView>
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/README.md
+++ b/README.md
@@ -69,7 +69,12 @@ If you have a real device you can install the Expo app from the App/Play store a
 For End-to-end testing we currently use Cypress to run the testing suite.
 In some Cypress tests, we request permission for the device’s location. As a result, you should run the tests using a browser - such as Chrome.
 
-Navigate to the root directory and enter the following into the console to run the tests:
+Before attempting to run Cypress tests, you must start the app and then click "Run in web browser":
+```
+expo start
+```
+
+Navigate to the project's root directory and enter the following into the console to run the tests:
 ```
 npx cypress run --browser chrome
 ```
@@ -81,7 +86,7 @@ To view this, navigate to:
 ### Jest and Enzyme tests
 For testing the React component, both Jest and Enzyme are used.
 
-Navigate to the root directory and enter the following into the console to run the tests:
+Navigate to the project's root directory and enter the following into the console to run the tests:
 ```
 npm test
 ```

--- a/styles.js
+++ b/styles.js
@@ -12,7 +12,8 @@ export default StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: '#fff',
-        zIndex: 10
+        zIndex: 10,
+        minHeight: '50%'
     },
     scrollContainer: {
       flex: 3,


### PR DESCRIPTION
### Android Drop Down Scrolling

Problem:
We were unable to scroll through the items in the drop down list (only an issue on Android)

Solution:
In order to scroll the list, we had to set the minHeight for the parent of the drop down list. However, this led to whitespace between the dropdown & restrictions Views. To address this, the restrictions View was moved into the dropdown View.

We can now scroll normally on Android, like we can on the other platforms.

Platforms tested: web on PC & Android.



### Alert Level Object

We now use existing alert level data in the councilList object, instead of making an extra call.

All Jest & Cypress tests have passed.